### PR TITLE
Autoresize text answer input height to fit the content

### DIFF
--- a/frontend/src/components/TextAnswer/TextAnswerEditor/index.js
+++ b/frontend/src/components/TextAnswer/TextAnswerEditor/index.js
@@ -83,8 +83,11 @@ function TextAnswerEditor({ question }) {
       <div className="text-box-container">
         <img className="GlobalDragDot" src={DragDots} alt="DragDots" />
         <Input.TextArea
-          placeholder="User types here..."
-          rows={5}
+          placeholder="[Height of input automatically adjusts based on content] User types here..."
+          autoSize={{
+            minRows: 1,
+            maxRows: 5,
+          }}
           className="text-box"
         />
       </div>

--- a/frontend/src/components/TextAnswer/index.js
+++ b/frontend/src/components/TextAnswer/index.js
@@ -20,8 +20,11 @@ function TextAnswer({ question }) {
       </div>
       <div className="text-box-container">
         <Input.TextArea
-          placeholder="User types here..."
-          rows={5}
+          placeholder="Type here..."
+          autoSize={{
+            minRows: 1,
+            maxRows: 5,
+          }}
           className="text-box"
           onBlur={(e) => {
             if (e.target.value !== "") {


### PR DESCRIPTION
#### Issue
Can text answer either be  short text (1 line) or long text (multiline)? Currently text box is a multiline box.

#### Implementation
I initially wanted to add a checkbox to the text answer editor that would toggle between the two text answer sizes. I decided against this because this would also require modifying the backend/database/redux to store this additional data. The solution implemented here is a textarea input box that starts off as a single row but automatically adjusts based on the size of the input content upto a max of 5 rows that was there initially.

![Untitled](https://user-images.githubusercontent.com/29956810/226123696-3db0e4bf-218f-4bcf-b38d-2d0eeb5c9230.jpg)

![Untitled2](https://user-images.githubusercontent.com/29956810/226123772-1bcc8bba-391a-4b35-8fe5-dcbd0f79a019.jpg)



