### PR TITLE
Allow text answers to either be only numbers or alphanumerical

### DIFF
--- a/backend/src/controllers/questionController.js
+++ b/backend/src/controllers/questionController.js
@@ -14,6 +14,7 @@ export default class QuestionController {
         mandatory: req.body.mandatory,
         clinical: req.body.clinical,
         question_note: req.body.question_note,
+        numerical_only: req.body.numerical_only,
       };
 
       QuestionModel.insertQuestion(question, (err, result) => {

--- a/backend/src/models/question.js
+++ b/backend/src/models/question.js
@@ -3,7 +3,7 @@ import con from "../config/Database.js";
 export class Question {
   insertQuestion(newQuestion, result) {
     con.query(
-      "CALL save_question(?, ?, ?, ?, ?, ?, ?, ?)",
+      "CALL save_question(?, ?, ?, ?, ?, ?, ?, ?,?)",
       [
         newQuestion.question_id,
         newQuestion.form_id,
@@ -13,6 +13,7 @@ export class Question {
         newQuestion.mandatory,
         newQuestion.clinical,
         newQuestion.question_note,
+        newQuestion.numerical_only,
       ],
       function (error, results) {
         if (error) {

--- a/database/init/questions.sql
+++ b/database/init/questions.sql
@@ -17,6 +17,7 @@ CREATE TABLE `questions` (
   `mandatory` BOOLEAN,
   `clinical` BOOLEAN,
   `question_note` TEXT,
+  `numerical_only` BOOLEAN,
   PRIMARY KEY (`question_id`),
   FOREIGN KEY (fk_form_id) REFERENCES forms(form_id) ON DELETE CASCADE  
 );

--- a/database/procedures/questionsProc.sql
+++ b/database/procedures/questionsProc.sql
@@ -12,7 +12,8 @@ CREATE PROCEDURE `save_question` (
     IN `_question_order` INT,
     IN `_mandatory` BOOLEAN,
     IN `_clinical` BOOLEAN,
-    IN `_question_note` TEXT
+    IN `_question_note` TEXT,
+    IN `_numerical_only` BOOLEAN
  
 ) BEGIN INSERT INTO `questions` (
     `question_id`,
@@ -22,7 +23,8 @@ CREATE PROCEDURE `save_question` (
     `position_index`,
     `mandatory`,
     `clinical`,
-    `question_note`
+    `question_note`,
+    `numerical_only`
 )
 VALUES
     (
@@ -33,7 +35,8 @@ VALUES
     `_question_order`,
     `_mandatory`,
     `_clinical`,
-    `_question_note`
+    `_question_note`,
+    `_numerical_only`
     )
 ON DUPLICATE KEY UPDATE 
     questions.question_id=`_question_id`, 
@@ -44,6 +47,7 @@ ON DUPLICATE KEY UPDATE
     questions.mandatory=`_mandatory`,
     questions.clinical=`_clinical`,
     questions.question_note=`_question_note`;
+    questions.numerical_only=`_numerical_only`;
   
 END $$
 

--- a/frontend/src/components/TextAnswer/TextAnswerEditor/index.css
+++ b/frontend/src/components/TextAnswer/TextAnswerEditor/index.css
@@ -12,3 +12,14 @@
   border-radius: 20px;
   padding: 20px
 }
+
+.editorInstructions{
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.editorInstructions > input{
+  flex: 1;
+}
+

--- a/frontend/src/components/TextAnswer/TextAnswerEditor/index.js
+++ b/frontend/src/components/TextAnswer/TextAnswerEditor/index.js
@@ -1,6 +1,9 @@
 import { Input } from "antd";
 import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useState } from "react";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormControl from "@mui/material/FormControl";
+import { Checkbox } from "@mui/material";
 import X from "../../../assets/X.png";
 import DragDots from "../../../assets/DragDots.png";
 import "./index.css";
@@ -21,6 +24,7 @@ function TextAnswerEditor({ question }) {
   const [questionNum, setQuestionNum] = useState("");
   const [title, setTitle] = useState("");
   const [note, setNote] = useState("");
+  const [numericalAnsOnly, setNumericalAnsOnly] = useState(false);
 
   useEffect(() => {
     setQuestionNum(`Q${question.position_index}`);
@@ -82,34 +86,54 @@ function TextAnswerEditor({ question }) {
           }}
         />
       </div>
-      <input
-        className="GlobalEditorQuestionNoteInput"
-        defaultValue={note}
-        placeholder="Type question note here..."
-        onBlur={(text) => {
-          dispatch({
-            type: SAVE_QUESTION,
-            payload: {
-              ...question,
-              form_id: question.fk_form_id,
-              question_title: question.question,
-              question_note: text.target.value,
-              question_index: question.position_index,
-            },
-          });
-          dispatch({ type: LOAD_QUESTION, payload: question.fk_form_id });
-        }}
-      />
+      <div className="editorInstructions">
+        <input
+          className="GlobalEditorQuestionNoteInput"
+          defaultValue={note}
+          placeholder="Type question note here..."
+          onBlur={(text) => {
+            dispatch({
+              type: SAVE_QUESTION,
+              payload: {
+                ...question,
+                form_id: question.fk_form_id,
+                question_title: question.question,
+                question_note: text.target.value,
+                question_index: question.position_index,
+              },
+            });
+            dispatch({ type: LOAD_QUESTION, payload: question.fk_form_id });
+          }}
+        />
+        <FormControl>
+          <FormControlLabel
+            control={
+              <Checkbox
+                onClick={() => setNumericalAnsOnly(!numericalAnsOnly)}
+              />
+            }
+            label={<span className="">Only allow numerical answers</span>}
+          />
+        </FormControl>
+      </div>
       <div className="text-box-container">
         <img className="GlobalDragDot" src={DragDots} alt="DragDots" />
-        <Input.TextArea
-          placeholder="[Height of input automatically adjusts based on content] User types here..."
-          autoSize={{
-            minRows: 1,
-            maxRows: 5,
-          }}
-          className="text-box"
-        />
+        {!numericalAnsOnly ? (
+          <Input.TextArea
+            placeholder="[Height of input automatically adjusts based on content] User types here..."
+            autoSize={{
+              minRows: 1,
+              maxRows: 5,
+            }}
+            className="text-box"
+          />
+        ) : (
+          <Input
+            placeholder="User types numerical answer here..."
+            className="text-box"
+            type="number"
+          />
+        )}
       </div>
       <EditComponentFooter question={question} />
     </div>

--- a/frontend/src/components/TextAnswer/TextAnswerEditor/index.js
+++ b/frontend/src/components/TextAnswer/TextAnswerEditor/index.js
@@ -109,7 +109,23 @@ function TextAnswerEditor({ question }) {
           <FormControlLabel
             control={
               <Checkbox
-                onClick={() => setNumericalAnsOnly(!numericalAnsOnly)}
+                onClick={() => {
+                  dispatch({
+                    type: SAVE_QUESTION,
+                    payload: {
+                      ...question,
+                      form_id: question.fk_form_id,
+                      question_title: question.question,
+                      question_index: question.position_index,
+                      numerical_only: !numericalAnsOnly,
+                    },
+                  });
+                  dispatch({
+                    type: LOAD_QUESTION,
+                    payload: question.fk_form_id,
+                  });
+                  setNumericalAnsOnly(!numericalAnsOnly);
+                }}
               />
             }
             label={<span className="">Only allow numerical answers</span>}
@@ -120,7 +136,7 @@ function TextAnswerEditor({ question }) {
         <img className="GlobalDragDot" src={DragDots} alt="DragDots" />
         {!numericalAnsOnly ? (
           <Input.TextArea
-            placeholder="[Height of input automatically adjusts based on content] User types here..."
+            placeholder="[Height of input automatically adjusts based on content] User types alphanumeric answer here..."
             autoSize={{
               minRows: 1,
               maxRows: 5,

--- a/frontend/src/components/TextAnswer/index.js
+++ b/frontend/src/components/TextAnswer/index.js
@@ -18,41 +18,76 @@ function TextAnswer({ question }) {
         {question.question}{" "}
         <p style={{ color: "red" }}>{question.mandatory ? "*" : ""}</p>
       </div>
-      <div className="customer__component__subtitle">{question.question_note}</div>
+      <div className="customer__component__subtitle">
+        {question.question_note}
+      </div>
       <div className="text-box-container-ta-cust">
-        <Input.TextArea
-          placeholder="Type here..."
-          autoSize={{
-            minRows: 1,
-            maxRows: 20,
-          }}
-          className="text-box-ta-cust"
-          onBlur={(e) => {
-            if (e.target.value !== "") {
-              dispatch({
-                type: REMOVE_SINGLE_RESPONSE,
-                payload: {
-                  question: question,
-                },
-              });
-              dispatch({
-                type: ADD_RESPONSE,
-                payload: {
-                  id: uuid(),
-                  response: e.target.value,
-                  question: question,
-                },
-              });
-            } else {
-              dispatch({
-                type: REMOVE_SINGLE_RESPONSE,
-                payload: {
-                  question: question,
-                },
-              });
-            }
-          }}
-        />
+        {question.numerical_only ? (
+          <Input
+            placeholder="Type numerical answer here..."
+            className="text-box-ta-cust"
+            type="number"
+            onBlur={(e) => {
+              if (e.target.value !== "") {
+                dispatch({
+                  type: REMOVE_SINGLE_RESPONSE,
+                  payload: {
+                    question: question,
+                  },
+                });
+                dispatch({
+                  type: ADD_RESPONSE,
+                  payload: {
+                    id: uuid(),
+                    response: e.target.value,
+                    question: question,
+                  },
+                });
+              } else {
+                dispatch({
+                  type: REMOVE_SINGLE_RESPONSE,
+                  payload: {
+                    question: question,
+                  },
+                });
+              }
+            }}
+          />
+        ) : (
+          <Input.TextArea
+            placeholder="Type alphanumeric answer here..."
+            autoSize={{
+              minRows: 1,
+              maxRows: 20,
+            }}
+            className="text-box-ta-cust"
+            onBlur={(e) => {
+              if (e.target.value !== "") {
+                dispatch({
+                  type: REMOVE_SINGLE_RESPONSE,
+                  payload: {
+                    question: question,
+                  },
+                });
+                dispatch({
+                  type: ADD_RESPONSE,
+                  payload: {
+                    id: uuid(),
+                    response: e.target.value,
+                    question: question,
+                  },
+                });
+              } else {
+                dispatch({
+                  type: REMOVE_SINGLE_RESPONSE,
+                  payload: {
+                    question: question,
+                  },
+                });
+              }
+            }}
+          />
+        )}
       </div>
       <Divider />
     </div>

--- a/frontend/src/redux/api/questionApi.js
+++ b/frontend/src/redux/api/questionApi.js
@@ -42,6 +42,7 @@ export const saveQuestions = async (payload) => {
       mandatory: payload.mandatory,
       clinical: payload.clinical,
       question_note: payload.question_note,
+      numerical_only: payload.numerical_only,
     });
 
     const questions = await axios.post("question/", data, { headers: headers });

--- a/frontend/src/screens/edit-request/edit-request.js
+++ b/frontend/src/screens/edit-request/edit-request.js
@@ -86,6 +86,7 @@ function EditRequest() {
       mandatory: false,
       clinical: false,
       question_note: "",
+      numerical_only: false,
     };
 
     dispatch({ type: SAVE_QUESTION, payload: newQuestion });


### PR DESCRIPTION
### Issue 
Allow text answers to either be only numbers or alphanumerical - can choose this setting from admin side? e.g. for telephone, sometimes people put in their extension as well

### Changes

- FE: allow the form maker to select if the user can only enter a numerical answer to the TextAnswer component. It renders either a Textarea for alphanumeric answers or a Number input otherwise
- Redux: `questionApi` to include numerical_answer option
- Database: numerical_answer to question init and procedure
- BE: relevant modifications to question controller and model

Please double check the backend and database modifications. I've tested that it works locally.

Admin side
![Untitled](https://user-images.githubusercontent.com/29956810/235271390-7cb8510c-63f9-4930-97f9-8a3b312a5f4e.jpg)

User facing side
![Untitled2](https://user-images.githubusercontent.com/29956810/235271410-5e587cab-1b1e-462a-a8a1-41923c07b192.jpg)

