### PR TITLE
0 option for user to clear dropdown answer

### DIFF
--- a/frontend/src/components/Dropdown/DropdownEditor/index.js
+++ b/frontend/src/components/Dropdown/DropdownEditor/index.js
@@ -219,7 +219,7 @@ function DropdownEditor({ question }) {
                   let autoNumVal = e.target.value;
                   autoNumVal = +autoNumVal;
                   if (autoNumVal > 0) {
-                    for (let i = 1; i <= autoNumVal; ++i) {
+                    for (let i = 0; i <= autoNumVal; ++i) {
                       dispatch({
                         type: SAVE_ANSWER,
                         payload: {


### PR DESCRIPTION
### Issue

Have an option to clear answer if you click it for drop-downs - e.g. for number of slides, once you click a number in the drop-down you can't click 0 after to clear the answer 

### Solution 

When autogenerating numerical dropdown options, include zero in the output. I'm assuming when the form maker adds dropdown options manually, they will add zero themselves.