### PR TITLE
Subtasks link

### DIFF
--- a/frontend/src/components/TicketBoard/Subtasks/index.css
+++ b/frontend/src/components/TicketBoard/Subtasks/index.css
@@ -26,10 +26,11 @@
   justify-content: space-between;
   margin-top: 12px;
   flex: 1;
-  background-color: #fcfcfc;
+  background-color: #ecedf3;
   color: #666666;
   border-radius: 10px;
   margin-right: 7px;
+  cursor: pointer;
 }
 
 .subtaskInputContainer {

--- a/frontend/src/components/TicketBoard/Subtasks/index.js
+++ b/frontend/src/components/TicketBoard/Subtasks/index.js
@@ -1,41 +1,49 @@
 import { useDispatch, useSelector } from "react-redux";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import FormControl from "@mui/material/FormControl";
-import { Checkbox } from "@mui/material";
 import "./index.css";
 import Add from "../../../assets/AddBlack.png";
-import { ADD_SUBTASKS } from "../../../redux/actions/ticketActions";
+import {
+  ADD_SUBTASKS,
+  SET_ACTIVE_TICKET
+} from "../../../redux/actions/ticketActions";
 
 function Subtasks({ readOnly }) {
   const dispatch = useDispatch();
+  const ticketBoardData = useSelector(
+    (state) => state.ticketReducer.ticketBoardDndData
+  );
   const currentTicket = useSelector(
     (state) => state.ticketReducer.currentTicket
   );
   const currentTicketSubtasks = useSelector(
     (state) => state.ticketReducer.currentTicketSubtasks
   );
+  const allTasks = ticketBoardData.tasks;
   return (
-    <div className="ticketSubtasks" style={{ borderRadius: readOnly ? 10 : null }}>
+    <div
+      className="ticketSubtasks"
+      style={{ borderRadius: readOnly ? 10 : null }}
+    >
       <div className="ticketSubtasksContainer">
         <div className="contentList">
           <div className="ticketSectionTitle">Subtasks</div>
           <div className="subtaskCostRows">
             {currentTicketSubtasks.map((subtasks) => {
               return (
-                <div className="subtaskCostRow" key={subtasks.subtask_id}>
+                <div
+                  className="subtaskCostRow"
+                  key={subtasks.subtask_id}
+                  onClick={() => {
+                    const subtaskTaskData = allTasks[subtasks?.subtask_uuid];
+                    dispatch({
+                      type: SET_ACTIVE_TICKET,
+                      payload: subtaskTaskData,
+                    });
+                  }}
+                >
                   <div className="subtaskInputContainer">
-                    <FormControl style={{ width: "100%" }}>
-                      <FormControlLabel
-                        control={
-                          <Checkbox
-                            onClick={() =>
-                              console.log("TODO: Mark subtask as complete")
-                            }
-                          />
-                        }
-                        label={<span className="subtasksLabel">{subtasks.subtask_title}</span>}
-                      />
-                    </FormControl>
+                    <span className="subtasksLabel">
+                      {subtasks.subtask_title}
+                    </span>
                   </div>
                 </div>
               );
@@ -43,18 +51,20 @@ function Subtasks({ readOnly }) {
           </div>
         </div>
 
-        {!readOnly ? <div
-          className="additionBar"
-          onClick={() => {
-            dispatch({
-              type: ADD_SUBTASKS,
-              payload: { task_id: currentTicket.code },
-            });
-          }}
-        >
-          <img className="Add" src={Add} alt="Add" />
-          <div className="ticketSectionTitle">Add Subtask</div>
-        </div> : null}
+        {!readOnly ? (
+          <div
+            className="additionBar"
+            onClick={() => {
+              dispatch({
+                type: ADD_SUBTASKS,
+                payload: { task_id: currentTicket.code },
+              });
+            }}
+          >
+            <img className="Add" src={Add} alt="Add" />
+            <div className="ticketSectionTitle">Add Subtask</div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/components/TicketBoard/TicketInfo/index.js
+++ b/frontend/src/components/TicketBoard/TicketInfo/index.js
@@ -50,6 +50,8 @@ export const TicketInfo = () => {
 
     const [assigneeAddModal, setAssigneeAddModal] = useState(false);
 
+    console.log(currentTicket)
+
     useEffect(() => {
         dispatch({ type: LOAD_EMPLOYEE });
         dispatch({ type: GET_TICKET_BOARD });
@@ -72,6 +74,7 @@ export const TicketInfo = () => {
     return (
         <div
             className="ticketDetailBackground"
+            key={currentTicket.task_uuid}
             onClick={() => {
                 if (assigneeAddModal) {
                     setAssigneeAddModal(false);

--- a/frontend/src/components/TicketBoard/TicketInfo/index.js
+++ b/frontend/src/components/TicketBoard/TicketInfo/index.js
@@ -50,8 +50,6 @@ export const TicketInfo = () => {
 
     const [assigneeAddModal, setAssigneeAddModal] = useState(false);
 
-    console.log(currentTicket)
-
     useEffect(() => {
         dispatch({ type: LOAD_EMPLOYEE });
         dispatch({ type: GET_TICKET_BOARD });


### PR DESCRIPTION
### Client issue
Have a link to sub-tasks from main task

### Desired behaviour
When user clicks on any subtask, ...

![Untitled](https://github.com/ubclaunchpad/labby/assets/29956810/019aff7f-2e11-4c2f-8fdf-0f4c097ff15e)

... the active modal changes to that specific subtask's task modal

![Untitled2](https://github.com/ubclaunchpad/labby/assets/29956810/07f70d7c-4300-4277-93a7-725eb4d6678f)

###  Solution implemented
Use the `SET_ACTIVE_TICKET` Redux action to replace the current ticket.

### Issues
Something that came up is the ticket modal would change to the subtask's ticket ( new SOW code, services and costs) but the title and description would remain the same as shown below.

![Untitled3](https://github.com/ubclaunchpad/labby/assets/29956810/74b553dc-109d-4990-9484-62ede592a74b)

After investigating it, I found this was caused by the way React works. [By default](https://react.dev/learn/preserving-and-resetting-state#resetting-state-at-the-same-position), a state of a component is preserved if it stays in the same position during rerenders. To reset this I  added the `currentTicket.task_uuid` as a key to the TicketInfo modal to reset the state when the currentTicket is changed by clicking on a subtask. As shown below, the issue is solved

![Untitled4](https://github.com/ubclaunchpad/labby/assets/29956810/12649715-1f4a-4d2a-ab38-557b298b8f18)

